### PR TITLE
Update Bevy to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,12 @@ thiserror = "1.0.38"
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-bevy = "0.10"
+bevy = { version = "0.10", default-features = false, features = [
+  "bevy_asset",
+  "bevy_core_pipeline",
+  "bevy_render",
+  "bevy_sprite",
+] }
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,16 @@ exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
 anyhow = "1.0.69"
-bevy_render = { version = "0.9.1", default-features = false }
-bevy_app = { version = "0.9.1", default-features = false }
-bevy_asset = { version = "0.9.1", default-features = false }
-bevy_ecs = { version = "0.9.1", default-features = false }
+bevy_render = { version = "0.10", default-features = false }
+bevy_app = { version = "0.10", default-features = false }
+bevy_asset = { version = "0.10", default-features = false }
+bevy_ecs = { version = "0.10", default-features = false }
 image = { version = "0.24", default-features = false }
 thiserror = "1.0.38"
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-bevy = "0.9.1"
+bevy = "0.10"
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
Update to the newest Bevy version.
Also reduce the set of active features for the Bevy dev dependency.