### PR TITLE
Emit warnings for missing documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
+
 mod loader;
 mod plugin;
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -5,6 +5,7 @@ use bevy_ecs::world::{FromWorld, World};
 use bevy_render::texture::{CompressedImageFormats, Image, ImageType};
 use zip::ZipArchive;
 
+/// An asset loader to load Krita's `.kra` files.
 #[derive(Debug, Clone)]
 pub struct KritaDocumentLoader;
 


### PR DESCRIPTION
Closes #3.

Enable compile warnings for missing documentation (which will be denied in CI).
I also added a missing doc comment detected by this.
The crate root will use the README as documentation.