### PR TITLE
Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,16 @@ exclude = ["assets/**/*", ".github/**/*"]
 
 [dependencies]
 anyhow = "1.0.69"
-bevy_render = { version = "0.10", default-features = false }
-bevy_app = { version = "0.10", default-features = false }
-bevy_asset = { version = "0.10", default-features = false }
-bevy_ecs = { version = "0.10", default-features = false }
+bevy_render = { version = "0.11", default-features = false }
+bevy_app = { version = "0.11", default-features = false }
+bevy_asset = { version = "0.11", default-features = false }
+bevy_ecs = { version = "0.11", default-features = false }
 image = { version = "0.24", default-features = false }
 thiserror = "1.0.38"
 zip = { version = "0.6.4", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
   "bevy_asset",
   "bevy_core_pipeline",
   "bevy_pbr",

--- a/examples/sprite.rs
+++ b/examples/sprite.rs
@@ -1,18 +1,21 @@
 //! Displays a single [`Sprite`], created from a Krita document.
 
+use std::time::Duration;
+
 use bevy::prelude::*;
+use bevy_asset::ChangeWatcher;
 use bevy_mod_krita::KritaPlugin;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(AssetPlugin {
             // Enable hot reloading
-            watch_for_changes: true,
+            watch_for_changes: ChangeWatcher::with_delay(Duration::from_millis(200)),
             ..default()
         }))
         // Add the Krita plugin to enable loading of `.kra` files
-        .add_plugin(KritaPlugin)
-        .add_startup_system(setup)
+        .add_plugins(KritaPlugin)
+        .add_systems(Startup, setup)
         .run();
 }
 

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use bevy::prelude::*;
+use bevy_asset::ChangeWatcher;
 use bevy_mod_krita::KritaPlugin;
 
 #[derive(Component)]
@@ -8,12 +11,12 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(AssetPlugin {
             // Enable hot reloading
-            watch_for_changes: true,
+            watch_for_changes: ChangeWatcher::with_delay(Duration::from_millis(200)),
             ..default()
         }))
-        .add_plugin(KritaPlugin)
-        .add_startup_system(setup)
-        .add_system(rotate_cube)
+        .add_plugins(KritaPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, rotate_cube)
         .run();
 }
 


### PR DESCRIPTION
# Objective

- Allow apps with `bevy@0.11` to use this plugin.
- Closes #16.

# Solution

Update `bevy` to 0.11, along with the examples.