### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_krita"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Tim Jentzsch"]
 description = "Use Krita's .kra files directly in your Bevy app."

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please keep in mind that `.kra` files are not optimized for size, so you should 
 
 | `bevy` version | `bevy_mod_krita` version |
 | -------------- | ------------------------ |
-| `0.12`         | `main`                   |
+| `0.12`         | `0.3.0`                   |
 | `0.11`         | `0.2.0`                  |
 | `0.10`         | `0.1.0`                  |
 


### PR DESCRIPTION
Releases `bevy_mod_krita` `0.3.0`, which adds support for `bevy` `0.12`.